### PR TITLE
Updating crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdwallet"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -15,13 +15,12 @@ members = [
 ]
 
 [dependencies]
-secp256k1 = "0.12"
-rand = "0.6.1"
+secp256k1 = "0.16"
+rand = "0.7"
 ring = "0.16.9"
-lazy_static = "1.2.0"
+lazy_static = "1.4"
 
 [dev-dependencies]
-hex = "0.3.2"
-base58 = "0.1.0"
-ripemd160 = "0.8.0"
-
+hex = "0.4"
+base58 = "0.1"
+ripemd160 = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 [dependencies]
 secp256k1 = "0.16"
 rand = "0.7"
-ring = "0.16.9"
+ring = "0.16"
 lazy_static = "1.4"
 
 [dev-dependencies]

--- a/hdwallet-bitcoin/Cargo.toml
+++ b/hdwallet-bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdwallet-bitcoin"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["jjy <jjyruby@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -9,8 +9,7 @@ keywords = [ "hdwallet", "BIP32", "wallet", "bitcoin", "crypto" ]
 description = "Bitcoin BIP-32 key derivation"
 
 [dependencies]
-hdwallet = { path = "..", version = "0.2.2" }
-hex = "0.3.2"
-base58 = "0.1.0"
-ripemd160 = "0.8.0"
-
+hdwallet = { path = "..", version = "0.2.4" }
+hex = "0.4"
+base58 = "0.1"
+ripemd160 = "0.8"


### PR DESCRIPTION
- I'm updating secp256k1 to "0.16" cause some other crates (such as https://crates.io/crates/bitcoin) use it and secp256k1 has `c` compiled code, so if I add distinct ones it fails linking them;
- I've removed the minor versions on `Cargo.toml` cause cargo can manage to get the last version.