### PR TITLE
Replace the `rand` dependency with `rand_core` & update dependency versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ members = [
 ]
 
 [dependencies]
-secp256k1 = "0.17"
-rand = "0.7"
+secp256k1 = "0.19"
+rand_core = "0.6.1"
 ring = "0.16"
 lazy_static = "1.4"
 
@@ -24,3 +24,4 @@ lazy_static = "1.4"
 hex = "0.4"
 base58 = "0.1"
 ripemd160 = "0.8"
+rand = "0.8.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,15 @@
 pub use crate::ChainPathError;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+use rand_core;
+
+#[derive(Debug)]
 pub enum Error {
     /// Index is out of range
     KeyIndexOutOfRange,
     /// ChainPathError
     ChainPath(ChainPathError),
     Secp(secp256k1::Error),
+    Rng(rand_core::Error),
 }
 
 impl From<ChainPathError> for Error {
@@ -18,5 +21,11 @@ impl From<ChainPathError> for Error {
 impl From<secp256k1::Error> for Error {
     fn from(err: secp256k1::Error) -> Error {
         Error::Secp(err)
+    }
+}
+
+impl From<rand_core::Error> for Error {
+    fn from(err: rand_core::Error) -> Self {
+        Error::Rng(err)
     }
 }

--- a/src/key_chain.rs
+++ b/src/key_chain.rs
@@ -36,8 +36,10 @@ impl Default for Derivation {
 /// ```rust
 /// # extern crate hdwallet;
 /// use hdwallet::{KeyChain, DefaultKeyChain, ChainPath, ExtendedPrivKey};
+/// use rand;
 ///
-/// let master_key = ExtendedPrivKey::random().unwrap();
+/// let mut rng = rand::thread_rng();
+/// let master_key = ExtendedPrivKey::random(&mut rng).unwrap();
 /// let key_chain = DefaultKeyChain::new(master_key);
 /// let child_key = key_chain.derive_private_key("m/0H/1".into()).unwrap();
 /// assert_eq!(child_key, key_chain.derive_private_key("m/0'/1".into()).unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,6 @@ pub use crate::key_chain::{
 };
 
 // re-exports
-pub use rand;
+pub use rand_core;
 pub use ring;
 pub use secp256k1;


### PR DESCRIPTION
By replacing the direct `rand::thread_rng()` calls with an explicitly
provided `RngCore + CryptoRng` source of randomness, this allows others
to reuse this code without being tied to the `rand` crate directly.

This also updates the secp256k1 dependency to a more current version.

If backward compatibility is a concern, how would you feel about the un-parameterized
version of ExtendedPrivKey::random to be available via a feature flag, so that
the dependency on `rand` can be optional?